### PR TITLE
Auth progress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,14 @@ mu_auth_db_PASSWORD="meetUN"
 
 ## Name for the database
 mu_auth_db_DB="auth"
+
+
+# --------------------------------- #
+# |       AUTH WHITELIST          | #
+# --------------------------------- #
+## hostname for which OTHER SERVICES
+## can find the WHITELIST SERVICE
+mu_auth_whitelist_HOSTNAME="mu_auth_whitelist"
+
+## port that the WHITELIST SERVICE listens to
+mu_auth_whitelist_INTERNAL_PORT=6379

--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ mu_auth_db_DB="auth"
 # --------------------------------- #
 ## hostname for which OTHER SERVICES
 ## can find the WHITELIST SERVICE
-mu_auth_whitelist_HOSTNAME="mu_auth_whitelist"
+mu_whitelist_db_HOSTNAME="mu_whitelist_db"
 
 ## port that the WHITELIST SERVICE listens to
-mu_auth_whitelist_INTERNAL_PORT=6379
+mu_whitelist_db_INTERNAL_PORT=6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
 
     depends_on:
       - mu_auth_db
+      - mu_auth_whitelist
 
     # Hostname for which the service will be reachable
     hostname: ${mu_auth_ms_HOSTNAME:-mu_auth_ms}
@@ -47,6 +48,19 @@ services:
       port: ${mu_auth_ms_INTERNAL_PORT:-5000}
 
     restart: on-failure:2 # NOTE: Service won't restart after failing twice
+
+  mu_auth_whitelist:
+    image: valkey/valkey:8-alpine
+
+    # Hostname for which the service will be reachable
+    hostname: ${mu_auth_whitelist_HOSTNAME:-mu_auth_whitelist}
+
+    # Ports exposed to OTHER SERVICES but NOT the HOST machine
+    expose:
+      - ${mu_auth_whitelist_INTERNAL_PORT:-6379}
+
+    restart: always
+    
 
 volumes:
   mu-auth-db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
     depends_on:
       - mu_auth_db
-      - mu_auth_whitelist
+      - mu_whitelist_db
 
     # Hostname for which the service will be reachable
     hostname: ${mu_auth_ms_HOSTNAME:-mu_auth_ms}
@@ -49,15 +49,15 @@ services:
 
     restart: on-failure:2 # NOTE: Service won't restart after failing twice
 
-  mu_auth_whitelist:
+  mu_whitelist_db:
     image: valkey/valkey:8-alpine
 
     # Hostname for which the service will be reachable
-    hostname: ${mu_auth_whitelist_HOSTNAME:-mu_auth_whitelist}
+    hostname: ${mu_whitelist_db_HOSTNAME:-mu_whitelist_db}
 
     # Ports exposed to OTHER SERVICES but NOT the HOST machine
     expose:
-      - ${mu_auth_whitelist_INTERNAL_PORT:-6379}
+      - ${mu_whitelist_db_INTERNAL_PORT:-6379}
 
     restart: always
     

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import helmet from "helmet"
 import cors from "cors"
 import signup from "./routes/signup"
 import login from "./routes/login"
+import auth_me from "./routes/auth_me"
 
 import dotenv from "dotenv"
 
@@ -35,5 +36,6 @@ app.get<{}>('/', (req, res) => {
 
 app.use(signup)
 app.use(login)
+app.use(auth_me)
 
 export default app

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,8 @@ import express from "express"
 import morgan from "morgan"
 import helmet from "helmet"
 import cors from "cors"
-import router from "./routes/signup"
+import signup from "./routes/signup"
+import login from "./routes/login"
 
 import dotenv from "dotenv"
 
@@ -32,6 +33,7 @@ app.get<{}>('/', (req, res) => {
   });
 });
 
-app.use(router)
+app.use(signup)
+app.use(login)
 
 export default app

--- a/src/middlewares/auth_middleware.ts
+++ b/src/middlewares/auth_middleware.ts
@@ -1,0 +1,45 @@
+import { NextFunction, Request, Response } from 'express';
+
+import jwt, { JsonWebTokenError } from 'jsonwebtoken';
+import { DataResponse } from '../interfaces/interfaces';
+
+export const verifyToken = async (req: Request, res: Response<DataResponse>, next: NextFunction) => {
+  const regex = /^Bearer (.+)$/;
+  const token = req.headers.authorization;
+
+  const response: DataResponse = {
+    data: null,
+    errors: [],
+  };
+
+  if (!token || typeof token !== 'string') {
+    response.errors.push({ message: 'No token provided' });
+    return res.status(401).json(response);
+  }
+  try {
+
+    const match = regex.exec(token);
+
+    if (match === null) {
+      throw new JsonWebTokenError('Invalid Bearer token');
+    }
+
+    const bearer = match[1];
+    //The logout endpoint needs the encoded token to remove it from the whitelist
+    res.locals.bearerToken = bearer;
+
+    // TODO: verify token is whitelisted. If not throw an exception
+
+    //The GET /auth/me endpoint needs the decoded token to easily return the user id
+    const decoded = jwt.verify( bearer, process.env.JWT_SECRET as string);
+    res.locals.decoded = decoded;
+
+    next();
+  } catch (err) {
+    console.log('Invalid token:', token);
+    console.error(err);
+    response.errors.push({ message: `Invalid token: ${token}` });
+
+    return res.status(401).json(response);
+  }
+};

--- a/src/routes/auth_me.ts
+++ b/src/routes/auth_me.ts
@@ -1,0 +1,19 @@
+import express from "express"
+import { DataResponse } from "../interfaces/interfaces"
+import { verifyToken } from "../middlewares/auth_middleware"
+
+const router = express.Router()
+
+router.get<{}, DataResponse>('/auth/me', async (req, res) => {
+
+    verifyToken(req, res, () => {
+        const response: DataResponse = {data: null, errors: []}
+        const decodedToken = res.locals.decoded
+        const userId = decodedToken.id
+        response.data = {id: userId}
+
+        res.status(200).json(response)
+    })
+})
+
+export default router

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -1,0 +1,77 @@
+import express from "express"
+import { DataResponse, AuthRequest, ErrorResponse } from "../interfaces/interfaces"
+
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { PrismaClient } from "@prisma/client";
+
+const router = express.Router()
+const prisma = new PrismaClient()
+
+router.post<{}, DataResponse, AuthRequest>('/login', async (req, res, next) => {
+    const response: DataResponse = { data: null, errors: [] }
+    const { email, password } = req.body as AuthRequest
+
+    //TODO: these two ifs are an exact copy of the ones in signup and should be abstracted, perhaps
+    //into some middleware that validates AuthRequests (signup and login)
+    if (typeof email !== 'string' || typeof password !== 'string') {
+        response.errors.push({ message: 'Invalid user information has been provided' })
+        res.status(400).json(response)
+        return
+    }
+    //MeetUN is meant to be an application exclusive to unal members
+    if (!email.toLowerCase().trim().endsWith("@unal.edu.co")) {
+        response.errors.push({ message: "Only @unal.edu.co emails are allowed" })
+        res.status(400).json(response)
+        return
+    }
+
+
+    const user = await prisma.user.findUnique({
+        where: { email },
+    }).catch( e => {
+        console.error('Unexpected error retrieving user', e)
+
+        response.errors.push({
+            message: 'Unexpected error retrieving user',
+            stack: e,
+        })
+        res.statusCode = 500
+
+        return null
+    });
+
+    if (res.statusCode === 500) {
+        next(response.errors[0])
+        return
+    }
+
+    // We do not reveal which of these two is incorrect to
+    //  prevent information leakage
+    const badCredentials: ErrorResponse = {
+        message: 'Wrong email or password',
+    }
+    //No user in the database has that email
+    if (user === null) {
+        response.errors.push(badCredentials)
+        res.status(401).json(response)
+        return
+    }
+    //The user exists but doesn't have that password
+    const passwordsMatch = await bcrypt.compare(password, user.password);
+    if (!passwordsMatch) {
+        response.errors.push(badCredentials);
+        res.status(401).json(response);
+        return
+    }
+
+    const token = jwt.sign({ id: user.id, expiresIn: process.env.USER_TOKEN_EXPIRATION_TIME as string }, 
+                                process.env.JWT_SECRET as string)
+    //TODO: add token to the whitelist
+
+    response.data = {id: user.id, jwt: token}
+    
+    res.status(200).json(response)
+})
+
+export default router


### PR DESCRIPTION
Adds a `/login` endpoint and a GET `/auth/me` endpoint which returns the user id corresponding to a given JWT (sent to the API on the Authorization header). The whitelist and the logout endpoint are still to be done.

This closes SwArch-2025-1-2A/project#18 and resolves SwArch-2025-1-2A/project#15