### PR TITLE
Add a delete endpoint to auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ mu_auth_ms_USER_TOKEN_EXPIRATION_TIME="3600"
 mu_auth_ms_INTERNAL_PORT=5000
 
 ## Port to be accessed from HOST machine
-mu_auth_ms_EXPOSED_PORT=5000
+mu_auth_ms_EXTERNAL_PORT=5000
 
 
 # --------------------------------- #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     # Hostname for which the service will be reachable
     hostname: ${mu_auth_db_HOSTNAME:-mu_auth_db}
 
+    container_name: ${mu_auth_db_HOSTNAME:-mu_auth_db}
+
     # Ports exposed to OTHER SERVICES but NOT the HOST machine
     expose:
       - ${mu_auth_db_INTERNAL_PORT:-5432}
@@ -38,7 +40,7 @@ services:
 
     # Ports available on the HOST machine
     ports:
-      - ${mu_auth_ms_EXPOSED_PORT:-5000}:${mu_auth_ms_INTERNAL_PORT:-5000}
+      - ${mu_auth_ms_EXTERNAL_PORT:-5000}:${mu_auth_ms_INTERNAL_PORT:-5000}
 
     environment:
       # `DATABASE_URL` is constructed from the `mu_auth_db` variables, like this:
@@ -48,7 +50,7 @@ services:
       JWT_SECRET: ${mu_auth_ms_JWT_SECRET:-defaultsecret}
       USER_TOKEN_EXPIRATION_TIME: ${mu_auth_ms_USER_TOKEN_EXPIRATION_TIME:-300}
       INTERNAL_PORT: ${mu_auth_ms_INTERNAL_PORT:-5000}
-      EXPOSED_PORT: ${mu_auth_ms_EXPOSED_PORT:-5000}
+      EXPOSED_PORT: ${mu_auth_ms_EXTERNAL_PORT:-5000}
 
     restart: on-failure:2 # NOTE: Service won't restart after failing twice
 
@@ -57,6 +59,8 @@ services:
 
     # Hostname for which the service will be reachable
     hostname: ${mu_whitelist_db_HOSTNAME:-mu_whitelist_db}
+
+    container_name: ${mu_whitelist_db_HOSTNAME:-mu_whitelist_db}
 
     # Ports exposed to OTHER SERVICES but NOT the HOST machine
     expose:

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/node": "^22.15.18",
         "eslint": "^9.27.0",
         "globals": "^16.1.0",
-        "prisma": "^6.8.2",
+        "prisma": "^6.10.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.32.1"
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.8.2.tgz",
-      "integrity": "sha512-ZJY1fF4qRBPdLQ/60wxNtX+eu89c3AkYEcP7L3jkp0IPXCNphCYxikTg55kPJLDOG6P0X+QG5tCv6CmsBRZWFQ==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
+      "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -373,53 +373,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.8.2.tgz",
-      "integrity": "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
+      "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.8.2.tgz",
-      "integrity": "sha512-XqAJ//LXjqYRQ1RRabs79KOY4+v6gZOGzbcwDQl0D6n9WBKjV7qdrbd042CwSK0v0lM9MSHsbcFnU2Yn7z8Zlw==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
+      "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.8.2",
-        "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-        "@prisma/fetch-engine": "6.8.2",
-        "@prisma/get-platform": "6.8.2"
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/fetch-engine": "6.10.1",
+        "@prisma/get-platform": "6.10.1"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e.tgz",
-      "integrity": "sha512-Rkik9lMyHpFNGaLpPF3H5q5TQTkm/aE7DsGM5m92FZTvWQsvmi6Va8On3pWvqLHOt5aPUvFb/FeZTmphI4CPiQ==",
+      "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
+      "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.8.2.tgz",
-      "integrity": "sha512-lCvikWOgaLOfqXGacEKSNeenvj0n3qR5QvZUOmPE2e1Eh8cMYSobxonCg9rqM6FSdTfbpqp9xwhSAOYfNqSW0g==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
+      "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.8.2",
-        "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-        "@prisma/get-platform": "6.8.2"
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/get-platform": "6.10.1"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.8.2.tgz",
-      "integrity": "sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
+      "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.8.2"
+        "@prisma/debug": "6.10.1"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2540,15 +2540,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.8.2.tgz",
-      "integrity": "sha512-JNricTXQxzDtRS7lCGGOB4g5DJ91eg3nozdubXze3LpcMl1oWwcFddrj++Up3jnRE6X/3gB/xz3V+ecBk/eEGA==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
+      "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.8.2",
-        "@prisma/engines": "6.8.2"
+        "@prisma/config": "6.10.1",
+        "@prisma/engines": "6.10.1"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^22.15.18",
     "eslint": "^9.27.0",
     "globals": "^16.1.0",
-    "prisma": "^6.8.2",
+    "prisma": "^6.10.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1"

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import signup from "./routes/signup"
 import login from "./routes/login"
 import auth_me from "./routes/auth_me"
 import logout from "./routes/logout"
+import deleteAuth from "./routes/delete"
 
 import dotenv from "dotenv"
 
@@ -59,5 +60,6 @@ app.use(signup)
 app.use(login)
 app.use(auth_me)
 app.use(logout)
+app.use(deleteAuth)
 
 export default app

--- a/src/routes/delete.ts
+++ b/src/routes/delete.ts
@@ -1,0 +1,39 @@
+import { PrismaClient } from "@prisma/client"
+import express from "express"
+import { verifyToken } from "../middlewares/auth_middleware"
+import { DataResponse } from "../interfaces/interfaces"
+import Redis from "ioredis"
+
+const router = express.Router()
+const prisma = new PrismaClient()
+
+router.delete<{}, DataResponse>("/auth/delete", async(req, res) => {
+    verifyToken(req, res, async() => {
+        const response : DataResponse = { data: null, errors: [] }
+        const userId = res.locals.decodedToken.id
+        const deleteUser = await prisma.user.delete({
+            where: {
+                id: userId
+            }
+        }).catch( e => {
+            console.log("Error deleting user:", e)
+            response.errors.push({ message: "Error deleting user", stack: e })
+
+            res.statusCode = 500
+            return null
+        })
+
+        if (!deleteUser) {
+            res.status(500).json(response)
+            return
+        }
+
+        const whitelist = res.locals.whitelist as Redis
+        const encodedToken = res.locals.encodedToken
+        whitelist.del(encodedToken)
+        res.status(204).json(response)
+        return
+    })
+})
+
+export default router


### PR DESCRIPTION
Even though deleting user's auth data isn't part of the requirements of our software, the orchestration between auth_ms and users_ms requires this endpoint so that if the creation of the user profile in users_ms fails, it is possible to roll back the creation of the user's auth data in the auth_ms. Otherwise we could end up with an inconsistent state: the user has been created in the auth database but not in the users database.

** NOTE **
Implementing a soft-delete would take a lot more effort because we would need to change the schema and update several endpoints. This is out of the scope of this PR, so I suggest creating a GitHub issue for it.